### PR TITLE
Allow wildcard for CNP

### DIFF
--- a/cilium/network_policy.cc
+++ b/cilium/network_policy.cc
@@ -478,10 +478,22 @@ class PolicyInstanceImpl : public PolicyInstance {
       return dst_port_;
     }
 
+    std::string findReplace(std::string str, const std::string& search,
+                                  const std::string& replace) {
+      size_t pos = 0;
+      while ((pos = str.find(search, pos)) != std::string::npos) {
+        str.replace(pos, search.length(), replace);
+        pos += replace.length();
+      }
+
+      return str;
+    }
+
     void processSpiffe(const ::cilium::Spiffe& spiffe) {
       is_spiffe_ = true;
       for (int i = 0; i < spiffe.peer_ids_size(); i++) {
-        spiffe_peer_ids_.push_back(spiffe.peer_ids(i));
+        std::string spiffeIDRegex = findReplace(spiffe.peer_ids(i), "*", ".+");
+        spiffe_peer_ids_.push_back(spiffeIDRegex);
       }
     }
 

--- a/cilium/tls_wrapper.cc
+++ b/cilium/tls_wrapper.cc
@@ -98,7 +98,8 @@ class SslSocketWrapper : public Network::TransportSocket {
           const auto& peerIDs = port_policy->getSpiffePeerIDs();
           for (const auto& id : peerIDs) {
               auto match = validation_context->add_match_subject_alt_names();
-              match->set_exact(id);
+              match->mutable_safe_regex()->mutable_google_re2();
+              match->mutable_safe_regex()->set_regex(id);
           }
 
           auto tls_certificate = tls_context->add_tls_certificates();


### PR DESCRIPTION
This commit allow a wildcard to be used inside a Cilium Network Policy.
The wildcard '*' (used by the user in the policy) is going to be
translate to '.+' for internal use of envoy regex.

This feature is related to this PR https://github.com/kubearmor/cilium/pull/8

Signed-off-by: Raphael Campos <raphael@accuknox.com>